### PR TITLE
Moving locals up in tag merging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,8 @@ locals {
   }
 
   tags = merge(
-    var.tags,
-    local.local_tags
+    local.local_tags,
+    var.tags
   )
 
   tags_as_list_of_maps = flatten([


### PR DESCRIPTION
The `merge()` function handles conflicting keys by accepting the latest occurrence of that key. Putting `var.tags` after `local.local_tags` allows overriding internal tags.